### PR TITLE
DEV: Add initial functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **Theme Name**
+# **Splash Screen**
 
 **Theme Summary**
 

--- a/about.json
+++ b/about.json
@@ -1,8 +1,8 @@
 {
-  "name": "TODO",
+  "name": "Splash Screen",
   "component": true,
   "authors": "Discourse",
-  "license_url": "TODO",
+  "license_url": "https://raw.githubusercontent.com/discourse/discourse-splash-screen/main/LICENSE",
   "about_url": "TODO",
   "learn_more": "TODO",
   "theme_version": "0.0.1",

--- a/common/common.scss
+++ b/common/common.scss
@@ -8,6 +8,16 @@
   position: fixed;
   text-align: center;
 
+  &__image {
+    width: 100%;
+    height: auto;
+
+    img {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
   &__content {
     padding: 1rem;
   }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,0 +1,39 @@
+.splash-screen {
+  display: none;
+  width: 100%;
+  height: 100%;
+  z-index: 9999;
+  background: var(--secondary);
+  color: var(--primary);
+  position: fixed;
+  text-align: center;
+
+  &__content {
+    padding: 1rem;
+  }
+
+  &__actions {
+    display: flex;
+    flex-flow: column nowrap;
+    padding: 1rem;
+    gap: 0.5rem;
+  }
+
+  &__indicators {
+    .d-icon {
+      opacity: 0.5;
+    }
+    .active .d-icon {
+      opacity: 1;
+      color: var(--tertiary);
+    }
+  }
+}
+
+html.splash-screen-active {
+  overflow: hidden;
+
+  .splash-screen {
+    display: block;
+  }
+}

--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -1,0 +1,170 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
+import { inject as service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import SwipeEvents from "discourse/lib/swipe-events";
+import DiscourseURL from "discourse/lib/url";
+import i18n from "discourse-common/helpers/i18n";
+import I18n from "discourse-i18n";
+import not from "truth-helpers/helpers/not";
+
+export default class SplashScreen extends Component {
+  static shouldRender(outletArgs, helper) {
+    if (helper.currentUser) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @service currentUser;
+  @service keyValueStore;
+  @tracked currentPage = 1;
+  swipeEvents = null;
+
+  constructor() {
+    super(...arguments);
+    document.documentElement.classList.add("splash-screen-active");
+
+    if (this.keyValueStore.getItem("seen-splash-screen") === undefined) {
+      this.keyValueStore.setItem("seen-splash-screen", true);
+    }
+
+    if (this.keyValueStore.getItem("seen-splash-screen") === true) {
+      this.currentPage = this.pages.length;
+    }
+  }
+
+  get pages() {
+    try {
+      const parsedData = JSON.parse(settings.slide_data);
+      return parsedData;
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("Error parsing JSON:", error);
+      // Skip the splash screen and jump to login prompt
+      return DiscourseURL.routeTo("/login");
+    }
+  }
+
+  get currentPageData() {
+    return this.pages[this.currentPage - 1];
+  }
+
+  get nextButtonLabel() {
+    if (this.onLastPage) {
+      return I18n.t(themePrefix("actions.finish"));
+    } else {
+      return I18n.t(themePrefix("actions.next"));
+    }
+  }
+
+  get onLastPage() {
+    return this.currentPage === this.pages.length;
+  }
+
+  @action
+  goToPage(page) {
+    this.currentPage = page + 1;
+  }
+
+  @action
+  goToPrevious() {
+    if (this.currentPage > 1) {
+      this.currentPage--;
+    }
+  }
+
+  @action
+  goToNext() {
+    if (this.onLastPage) {
+      document.documentElement.classList.remove("splash-screen-active");
+      DiscourseURL.routeTo("/login");
+    }
+
+    if (this.currentPage < this.pages.length) {
+      this.currentPage++;
+    }
+  }
+
+  @action
+  goToEnd() {
+    this.currentPage = this.pages.length;
+  }
+
+  @action
+  pageIsActive(index) {
+    return this.currentPage === index + 1 ? "active" : "";
+  }
+
+  @action
+  handleSwipeEnd(event) {
+    if (event.detail.deltaX > 0) {
+      this.goToPrevious();
+    } else {
+      this.goToNext();
+    }
+  }
+
+  @action
+  setupEvents(element) {
+    this.swipeEvents = new SwipeEvents(element);
+    this.swipeEvents.addTouchListeners();
+    element.addEventListener("swipeend", this.handleSwipeEnd);
+  }
+
+  teardownEvents(element) {
+    this.swipeEvents.removeTouchListeners();
+    element.removeEventListener("swipeend", this.handleSwipeEnd);
+    document.documentElement.classList.remove("splash-screen-active");
+  }
+
+  <template>
+    <div
+      class="splash-screen"
+      {{didInsert this.setupEvents this.pages}}
+      {{willDestroy this.teardownEvents this.pages}}
+    >
+      {{! TODO: Add background image }}
+
+      <div class="splash-screen__content">
+        <h1
+          class="splash-screen__content__title"
+        >{{this.currentPageData.title}}</h1>
+        <p
+          class="splash-screen__content__description"
+        >{{this.currentPageData.description}}</p>
+      </div>
+
+      <div class="splash-screen__indicators">
+        {{#each this.pages as |page index|}}
+          <DButton
+            @class="btn-transparent {{this.pageIsActive index}}"
+            @icon="circle"
+            @action={{this.goToPage}}
+            @actionParam={{index}}
+          />
+        {{/each}}
+      </div>
+
+      <div class="splash-screen__actions">
+        {{#if (not this.onLastPage)}}
+          <DButton
+            @class="btn-flat splash-screen__actions__skip"
+            @translatedLabel={{i18n (themePrefix "actions.skip")}}
+            @action={{this.goToEnd}}
+          />
+        {{/if}}
+
+        <DButton
+          @class="btn-primary splash-screen__actions__next"
+          @translatedLabel={{this.nextButtonLabel}}
+          @action={{this.goToNext}}
+        />
+      </div>
+    </div>
+  </template>
+}

--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -125,9 +125,7 @@ export default class SplashScreen extends Component {
     >
       {{#if this.currentPageData.background_image_url}}
         <div class="splash-screen__image">
-          <img 
-            src={{this.currentPageData.background_image_url}}
-          />
+          <img src={{this.currentPageData.background_image_url}} />
         </div>
       {{/if}}
 

--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -42,8 +42,6 @@ export default class SplashScreen extends Component {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error("Error parsing JSON:", error);
-      // Skip the splash screen and jump to login prompt
-      return DiscourseURL.routeTo("/login");
     }
   }
 

--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -123,7 +123,13 @@ export default class SplashScreen extends Component {
       {{didInsert this.setupEvents this.pages}}
       {{willDestroy this.teardownEvents this.pages}}
     >
-      {{! TODO: Add background image }}
+      {{#if this.currentPageData.background_image_url}}
+        <div class="splash-screen__image">
+          <img 
+            src={{this.currentPageData.background_image_url}}
+          />
+        </div>
+      {{/if}}
 
       <div class="splash-screen__content">
         <h1

--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -9,7 +9,6 @@ import SwipeEvents from "discourse/lib/swipe-events";
 import DiscourseURL from "discourse/lib/url";
 import i18n from "discourse-common/helpers/i18n";
 import I18n from "discourse-i18n";
-import not from "truth-helpers/helpers/not";
 
 export default class SplashScreen extends Component {
   static shouldRender(outletArgs, helper) {
@@ -151,13 +150,13 @@ export default class SplashScreen extends Component {
       </div>
 
       <div class="splash-screen__actions">
-        {{#if (not this.onLastPage)}}
+        {{#unless this.onLastPage}}
           <DButton
             @class="btn-flat splash-screen__actions__skip"
             @translatedLabel={{i18n (themePrefix "actions.skip")}}
             @action={{this.goToEnd}}
           />
-        {{/if}}
+        {{/unless}}
 
         <DButton
           @class="btn-primary splash-screen__actions__next"

--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -30,9 +30,7 @@ export default class SplashScreen extends Component {
 
     if (this.keyValueStore.getItem("seen-splash-screen") === undefined) {
       this.keyValueStore.setItem("seen-splash-screen", true);
-    }
-
-    if (this.keyValueStore.getItem("seen-splash-screen") === true) {
+    } else if (this.keyValueStore.getItem("seen-splash-screen") === "true") {
       this.currentPage = this.pages.length;
     }
   }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,2 +1,6 @@
 en:
-  placeholder: placeholder
+  actions:
+    skip: "Skip"
+    previous: "Previous"
+    next: "Next"
+    finish: "Start"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "TODO",
+  "name": "discourse-splash-screen",
   "version": "0.0.1",
-  "repository": "TODO",
+  "repository": "https://github.com/discourse/discourse-splash-screen",
   "author": "Discourse",
   "license": "MIT",
   "devDependencies": {

--- a/settings.yml
+++ b/settings.yml
@@ -1,4 +1,25 @@
-example_setting:
-  default: true
-  description:
-    en: A description of a setting.
+slide_data:
+  default: "[]"
+  json_schema: >-
+    {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "background_image_url": {
+            "type": "string",
+            "format": "url"
+          }
+        },
+        "additionalProperties": false
+      }
+    }

--- a/spec/system/page_objects/components/splash_screen.rb
+++ b/spec/system/page_objects/components/splash_screen.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class SplashScreen < PageObjects::Components::Base
+      SPLASH_SCREEN_SELECTOR = ".splash-screen"
+      CONTENT_SELECTOR = "#{SPLASH_SCREEN_SELECTOR}__content"
+      INDICATORS_SELECTOR = "#{SPLASH_SCREEN_SELECTOR}__indicators"
+      ACTIONS_SELECTOR = "#{SPLASH_SCREEN_SELECTOR}__actions"
+
+      def click_next_button
+        find("#{ACTIONS_SELECTOR} .splash-screen__actions__next").click
+      end
+
+      def click_skip_button
+        find("#{ACTIONS_SELECTOR} .splash-screen__actions__skip").click
+      end
+
+      def click_indicator(index)
+        find("#{INDICATORS_SELECTOR} .btn:nth-child(#{index})").click
+      end
+
+      def has_splash_screen?
+        page.has_css?(SPLASH_SCREEN_SELECTOR)
+      end
+
+      def has_no_splash_screen?
+        page.has_no_css?(SPLASH_SCREEN_SELECTOR)
+      end
+
+      def has_heading?(title)
+        page.find("#{CONTENT_SELECTOR}__title").text == title
+      end
+
+      def has_description?(description)
+        page.find("#{CONTENT_SELECTOR}__description").text == description
+      end
+    end
+  end
+end

--- a/spec/system/splash_screen_spec.rb
+++ b/spec/system/splash_screen_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative "page_objects/components/splash_screen"
+
+RSpec.describe "Splash screen spec", system: true do
+  let!(:theme_component) { upload_theme_component }
+  let(:splash_screen) { PageObjects::Components::SplashScreen.new }
+  fab!(:user)
+
+  before do
+    settings_data =
+      '[{"title":"Welcome to Our App","description":"Explore the amazing features and functionalities of our app.","background_image_url":"https://example.com/background1.jpg"},{"title":"Discover Exciting Possibilities","description":"Dive into a world of innovation and possibilities with our app.","background_image_url":"https://example.com/background2.jpg"},{"title":"Connect with Others","description":"Build meaningful connections and share experiences with our community.","background_image_url":"https://example.com/background3.jpg"},{"title":"Unleash Your Creativity","description":"Express yourself and unleash your creativity using our powerful tools.","background_image_url":"https://example.com/background4.jpg"},{"title":"Ready to Get Started?","description":"Join us now and experience a new level of convenience and excitement.","background_image_url":"https://example.com/background5.jpg"}]'
+    theme_component.update_setting(:slide_data, settings_data)
+    theme_component.save!
+  end
+
+  context "when user is not logged in" do
+    it "should show the splash screen" do
+      visit("/")
+      expect(splash_screen).to have_splash_screen
+    end
+
+    it "should show the correct title and description" do
+      slide_1_title = "Welcome to Our App"
+      slide_1_description =
+        "Explore the amazing features and functionalities of our app."
+      visit("/")
+      expect(splash_screen).to have_heading(slide_1_title)
+      expect(splash_screen).to have_description(slide_1_description)
+    end
+
+    it "should change to the next slide when clicking the next button" do
+      slide_1_title = "Welcome to Our App"
+      slide_1_description =
+        "Explore the amazing features and functionalities of our app."
+      slide_2_title = "Discover Exciting Possibilities"
+      slide_2_description =
+        "Dive into a world of innovation and possibilities with our app."
+
+      visit("/")
+      expect(splash_screen).to have_heading(slide_1_title)
+      expect(splash_screen).to have_description(slide_1_description)
+      splash_screen.click_next_button
+      expect(splash_screen).to have_heading(slide_2_title)
+      expect(splash_screen).to have_description(slide_2_description)
+    end
+
+    it "should skip to the last slide when clicking the skip button" do
+      final_title = "Ready to Get Started?"
+      final_description =
+        "Join us now and experience a new level of convenience and excitement."
+
+      visit("/")
+      splash_screen.click_skip_button
+      expect(splash_screen).to have_heading(final_title)
+      expect(splash_screen).to have_description(final_description)
+    end
+
+    it "should go to the page when clicking on the indicator dot" do
+      slide_3_title = "Connect with Others"
+      slide_3_description =
+        "Build meaningful connections and share experiences with our community."
+
+      visit("/")
+      splash_screen.click_indicator(3)
+      expect(splash_screen).to have_heading(slide_3_title)
+      expect(splash_screen).to have_description(slide_3_description)
+    end
+
+    it "should go to the login page after clicking through all the slides" do
+      visit("/")
+      splash_screen.click_skip_button
+      splash_screen.click_next_button
+      expect(page).to have_css(".login-modal")
+      expect(splash_screen).to have_no_splash_screen
+    end
+  end
+
+  context "when user is logged in" do
+    before { sign_in(user) }
+
+    it "should not show the splash screen" do
+      visit("/")
+      expect(splash_screen).to have_no_splash_screen
+    end
+  end
+end

--- a/spec/system/splash_screen_spec.rb
+++ b/spec/system/splash_screen_spec.rb
@@ -74,6 +74,18 @@ RSpec.describe "Splash screen spec", system: true do
       expect(page).to have_css(".login-modal")
       expect(splash_screen).to have_no_splash_screen
     end
+
+    context "when the user has already seen the splash screen" do
+      before { visit("/") }
+
+      it "should skip to the last page of the splash screen" do
+        visit("/")
+        expect(splash_screen).to have_heading("Ready to Get Started?")
+        expect(splash_screen).to have_description(
+          "Join us now and experience a new level of convenience and excitement."
+        )
+      end
+    end
   end
 
   context "when user is logged in" do


### PR DESCRIPTION
This PR adds the initial functionality for this theme-component.

Namely:
- show a splash screen to anonymous user
- add admin customizable pages with title, description, and background image attributes
- add skip and next buttons to navigate screens
- add swipe functionality to swipe between screens on mobile

## Preview

https://github.com/discourse/discourse-splash-screen/assets/30090424/d48343aa-0a3c-409f-ba86-0800b48a908c


