### PR TITLE
DEV: Skip button should skip to login page instead

### DIFF
--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -31,7 +31,7 @@ export default class SplashScreen extends Component {
     if (this.keyValueStore.getItem("seen-splash-screen") === undefined) {
       this.keyValueStore.setItem("seen-splash-screen", true);
     } else if (this.keyValueStore.getItem("seen-splash-screen") === "true") {
-      this.currentPage = this.pages.length;
+      this.skipSplashScreen();
     }
   }
 
@@ -76,8 +76,7 @@ export default class SplashScreen extends Component {
   @action
   goToNext() {
     if (this.onLastPage) {
-      document.documentElement.classList.remove("splash-screen-active");
-      DiscourseURL.routeTo("/login");
+      this.skipSplashScreen();
     }
 
     if (this.currentPage < this.pages.length) {
@@ -86,8 +85,9 @@ export default class SplashScreen extends Component {
   }
 
   @action
-  goToEnd() {
-    this.currentPage = this.pages.length;
+  skipSplashScreen() {
+    document.documentElement.classList.remove("splash-screen-active");
+    DiscourseURL.routeTo("/login");
   }
 
   @action
@@ -154,7 +154,7 @@ export default class SplashScreen extends Component {
           <DButton
             @class="btn-flat splash-screen__actions__skip"
             @translatedLabel={{i18n (themePrefix "actions.skip")}}
-            @action={{this.goToEnd}}
+            @action={{this.skipSplashScreen}}
           />
         {{/unless}}
 

--- a/spec/system/splash_screen_spec.rb
+++ b/spec/system/splash_screen_spec.rb
@@ -45,15 +45,11 @@ RSpec.describe "Splash screen spec", system: true do
       expect(splash_screen).to have_description(slide_2_description)
     end
 
-    it "should skip to the last slide when clicking the skip button" do
-      final_title = "Ready to Get Started?"
-      final_description =
-        "Join us now and experience a new level of convenience and excitement."
-
+    it "should skip to the login page when clicking the skip button" do
       visit("/")
       splash_screen.click_skip_button
-      expect(splash_screen).to have_heading(final_title)
-      expect(splash_screen).to have_description(final_description)
+      expect(page).to have_css(".login-modal")
+      expect(splash_screen).to have_no_splash_screen
     end
 
     it "should go to the page when clicking on the indicator dot" do
@@ -69,8 +65,7 @@ RSpec.describe "Splash screen spec", system: true do
 
     it "should go to the login page after clicking through all the slides" do
       visit("/")
-      splash_screen.click_skip_button
-      splash_screen.click_next_button
+      5.times { splash_screen.click_next_button }
       expect(page).to have_css(".login-modal")
       expect(splash_screen).to have_no_splash_screen
     end
@@ -78,12 +73,10 @@ RSpec.describe "Splash screen spec", system: true do
     context "when the user has already seen the splash screen" do
       before { visit("/") }
 
-      it "should skip to the last page of the splash screen" do
+      it "should skip to the login page" do
         visit("/")
-        expect(splash_screen).to have_heading("Ready to Get Started?")
-        expect(splash_screen).to have_description(
-          "Join us now and experience a new level of convenience and excitement."
-        )
+        expect(page).to have_css(".login-modal")
+        expect(splash_screen).to have_no_splash_screen
       end
     end
   end


### PR DESCRIPTION
This PR updates the logic so that the <kbd>Skip</kbd> button routes the page to the `/login` screen instead of the last page of the splash screen.