### PR TITLE
DEV: Add page number for theming easily

### DIFF
--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -120,6 +120,7 @@ export default class SplashScreen extends Component {
   <template>
     <div
       class="splash-screen"
+      data-page={{this.currentPage}}
       {{didInsert this.setupEvents this.pages}}
       {{willDestroy this.teardownEvents this.pages}}
     >


### PR DESCRIPTION
This PR adds the page number to the splash screen `<div>` for easier theming of each page.