### PR TITLE
Various adjustments

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,7 +9,6 @@
   color: var(--primary);
   position: fixed;
   text-align: center;
-
   flex-direction: column;
   justify-content: flex-end;
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,5 +1,6 @@
 .splash-screen {
   padding-block: 4rem;
+  box-sizing: border-box;
   display: none;
   width: 100%;
   height: 100%;
@@ -9,9 +10,12 @@
   position: fixed;
   text-align: center;
 
+  flex-direction: column;
+  justify-content: flex-end;
+
   &__image {
     width: 100%;
-    height: auto;
+    flex-grow: 4;
 
     img {
       mask-image: linear-gradient(
@@ -53,6 +57,6 @@ html.splash-screen-active {
   overflow: hidden;
 
   .splash-screen {
-    display: block;
+    display: flex;
   }
 }

--- a/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
+++ b/javascripts/discourse/connectors/above-site-header/splash-screen.gjs
@@ -12,12 +12,14 @@ import I18n from "discourse-i18n";
 
 export default class SplashScreen extends Component {
   static shouldRender(outletArgs, helper) {
-
     if (helper.currentUser || helper.site.desktopView) {
       return false;
     }
 
-    if (settings.only_show_mobile_app && window.ReactNativeWebView === undefined) {
+    if (
+      settings.only_show_mobile_app &&
+      window.ReactNativeWebView === undefined
+    ) {
       return false;
     }
 

--- a/settings.yml
+++ b/settings.yml
@@ -27,3 +27,8 @@ slide_data:
         "additionalProperties": false
       }
     }
+only_show_mobile_app:
+  type: bool
+  default: false
+  description:
+    en: "Only show on mobile app."

--- a/spec/system/splash_screen_spec.rb
+++ b/spec/system/splash_screen_spec.rb
@@ -5,11 +5,11 @@ require_relative "page_objects/components/splash_screen"
 RSpec.describe "Splash screen spec", system: true do
   let!(:theme_component) { upload_theme_component }
   let(:splash_screen) { PageObjects::Components::SplashScreen.new }
+  let!(:settings_data) { '[{"title":"Welcome to Our App","description":"Explore the amazing features and functionalities of our app.","background_image_url":"https://example.com/background1.jpg"},{"title":"Discover Exciting Possibilities","description":"Dive into a world of innovation and possibilities with our app.","background_image_url":"https://example.com/background2.jpg"},{"title":"Connect with Others","description":"Build meaningful connections and share experiences with our community.","background_image_url":"https://example.com/background3.jpg"},{"title":"Unleash Your Creativity","description":"Express yourself and unleash your creativity using our powerful tools.","background_image_url":"https://example.com/background4.jpg"},{"title":"Ready to Get Started?","description":"Join us now and experience a new level of convenience and excitement.","background_image_url":"https://example.com/background5.jpg"}]' }
+  let!(:settings_array) { JSON.parse(settings_data) }
   fab!(:user)
 
   before do
-    settings_data =
-      '[{"title":"Welcome to Our App","description":"Explore the amazing features and functionalities of our app.","background_image_url":"https://example.com/background1.jpg"},{"title":"Discover Exciting Possibilities","description":"Dive into a world of innovation and possibilities with our app.","background_image_url":"https://example.com/background2.jpg"},{"title":"Connect with Others","description":"Build meaningful connections and share experiences with our community.","background_image_url":"https://example.com/background3.jpg"},{"title":"Unleash Your Creativity","description":"Express yourself and unleash your creativity using our powerful tools.","background_image_url":"https://example.com/background4.jpg"},{"title":"Ready to Get Started?","description":"Join us now and experience a new level of convenience and excitement.","background_image_url":"https://example.com/background5.jpg"}]'
     theme_component.update_setting(:slide_data, settings_data)
     theme_component.save!
   end
@@ -39,28 +39,18 @@ RSpec.describe "Splash screen spec", system: true do
     end
 
     it "should show the correct title and description" do
-      slide_1_title = "Welcome to Our App"
-      slide_1_description =
-        "Explore the amazing features and functionalities of our app."
       visit("/")
-      expect(splash_screen).to have_heading(slide_1_title)
-      expect(splash_screen).to have_description(slide_1_description)
+      expect(splash_screen).to have_heading(settings_array[0]["title"])
+      expect(splash_screen).to have_description(settings_array[0]["description"])
     end
 
     it "should change to the next slide when clicking the next button" do
-      slide_1_title = "Welcome to Our App"
-      slide_1_description =
-        "Explore the amazing features and functionalities of our app."
-      slide_2_title = "Discover Exciting Possibilities"
-      slide_2_description =
-        "Dive into a world of innovation and possibilities with our app."
-
       visit("/")
-      expect(splash_screen).to have_heading(slide_1_title)
-      expect(splash_screen).to have_description(slide_1_description)
+      expect(splash_screen).to have_heading(settings_array[0]["title"])
+      expect(splash_screen).to have_description(settings_array[0]["description"])
       splash_screen.click_next_button
-      expect(splash_screen).to have_heading(slide_2_title)
-      expect(splash_screen).to have_description(slide_2_description)
+      expect(splash_screen).to have_heading(settings_array[1]["title"])
+      expect(splash_screen).to have_description(settings_array[1]["description"])
     end
 
     it "should skip to the login page when clicking the skip button" do
@@ -71,14 +61,10 @@ RSpec.describe "Splash screen spec", system: true do
     end
 
     it "should go to the page when clicking on the indicator dot" do
-      slide_3_title = "Connect with Others"
-      slide_3_description =
-        "Build meaningful connections and share experiences with our community."
-
       visit("/")
       splash_screen.click_indicator(3)
-      expect(splash_screen).to have_heading(slide_3_title)
-      expect(splash_screen).to have_description(slide_3_description)
+      expect(splash_screen).to have_heading(settings_array[2]["title"])
+      expect(splash_screen).to have_description(settings_array[2]["description"])
     end
 
     it "should go to the login page after clicking through all the slides" do
@@ -91,10 +77,11 @@ RSpec.describe "Splash screen spec", system: true do
     context "when the user has already seen the splash screen" do
       before { visit("/") }
 
-      it "should skip to the login page" do
+      it "should default to the last page of the splash screen" do
         visit("/")
-        expect(page).to have_css(".login-modal")
-        expect(splash_screen).to have_no_splash_screen
+
+        expect(splash_screen).to have_heading(settings_array[settings_array.length - 1]["title"])
+        expect(splash_screen).to have_description(settings_array[settings_array.length - 1]["description"])
       end
     end
   end


### PR DESCRIPTION
1. Add setting to only show on mobile app.
2. For returning anon users, skip to the last step of the splash screen. This is a better default thank skipping entirely (the app is for creators) who need to be logged in, so it doesn't make sense to show the anon content.
3. Fix a couple of issues with the login process.